### PR TITLE
geom_alt props

### DIFF
--- a/data/421/169/419/421169419.geojson
+++ b/data/421/169/419/421169419.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459008809,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b1f4349c427982059fbbe90b3011edc",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421169419,
-    "wof:lastmodified":1566637755,
+    "wof:lastmodified":1582326388,
     "wof:name":"Nyabihu",
     "wof:parent_id":85676791,
     "wof:placetype":"county",

--- a/data/421/171/291/421171291.geojson
+++ b/data/421/171/291/421171291.geojson
@@ -468,6 +468,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459008888,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"07e8abe775be92a5dc8807d2dfedc7bf",
     "wof:hierarchy":[
         {
@@ -479,7 +482,7 @@
         }
     ],
     "wof:id":421171291,
-    "wof:lastmodified":1566637768,
+    "wof:lastmodified":1582326397,
     "wof:name":"Kigali",
     "wof:parent_id":421204011,
     "wof:placetype":"locality",

--- a/data/421/174/099/421174099.geojson
+++ b/data/421/174/099/421174099.geojson
@@ -183,6 +183,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009019,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2e5aa2bf64a3b8f35c57c1b68123ea43",
     "wof:hierarchy":[
         {
@@ -194,7 +197,7 @@
         }
     ],
     "wof:id":421174099,
-    "wof:lastmodified":1566637759,
+    "wof:lastmodified":1582326391,
     "wof:name":"Ruhengeri",
     "wof:parent_id":421187899,
     "wof:placetype":"locality",

--- a/data/421/175/213/421175213.geojson
+++ b/data/421/175/213/421175213.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009059,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d0f1e0c21e7d2994af92fdcb7a71491",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421175213,
-    "wof:lastmodified":1566637762,
+    "wof:lastmodified":1582326392,
     "wof:name":"Gicumbi",
     "wof:parent_id":85676799,
     "wof:placetype":"county",

--- a/data/421/175/701/421175701.geojson
+++ b/data/421/175/701/421175701.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009076,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e98d0ab703fd61c307404931b6b9f1a2",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421175701,
-    "wof:lastmodified":1566637761,
+    "wof:lastmodified":1582326392,
     "wof:name":"Kirehe",
     "wof:parent_id":85676795,
     "wof:placetype":"county",

--- a/data/421/176/723/421176723.geojson
+++ b/data/421/176/723/421176723.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009117,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e374f1f165f67b9df32ff971c4e5716",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421176723,
-    "wof:lastmodified":1566637767,
+    "wof:lastmodified":1582326396,
     "wof:name":"Rusizi",
     "wof:parent_id":85676791,
     "wof:placetype":"county",

--- a/data/421/180/243/421180243.geojson
+++ b/data/421/180/243/421180243.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009249,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"82617090607ad8497f8cddec7da6805e",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421180243,
-    "wof:lastmodified":1566637759,
+    "wof:lastmodified":1582326391,
     "wof:name":"Burera",
     "wof:parent_id":85676799,
     "wof:placetype":"county",

--- a/data/421/182/175/421182175.geojson
+++ b/data/421/182/175/421182175.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009321,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c63c4622d71e2f52a5db90de75dcaa67",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421182175,
-    "wof:lastmodified":1566637766,
+    "wof:lastmodified":1582326395,
     "wof:name":"Karongi",
     "wof:parent_id":85676791,
     "wof:placetype":"county",

--- a/data/421/182/309/421182309.geojson
+++ b/data/421/182/309/421182309.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009325,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"338e413b3b624e611a01cecab03013e1",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421182309,
-    "wof:lastmodified":1566637766,
+    "wof:lastmodified":1582326395,
     "wof:name":"Kicukiro",
     "wof:parent_id":85676807,
     "wof:placetype":"county",

--- a/data/421/187/891/421187891.geojson
+++ b/data/421/187/891/421187891.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009527,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"58583f80a0ab2fdd8dd4b76179e4f8d6",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421187891,
-    "wof:lastmodified":1566637760,
+    "wof:lastmodified":1582326391,
     "wof:name":"Rwamagana",
     "wof:parent_id":85676795,
     "wof:placetype":"county",

--- a/data/421/187/897/421187897.geojson
+++ b/data/421/187/897/421187897.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009527,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8019958c6f181c1741af76185e13d0f6",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421187897,
-    "wof:lastmodified":1566637760,
+    "wof:lastmodified":1582326392,
     "wof:name":"Musanze",
     "wof:parent_id":85676799,
     "wof:placetype":"county",

--- a/data/421/187/899/421187899.geojson
+++ b/data/421/187/899/421187899.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009527,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b2eb868e0eb3b35ba6a0c5021996ad7d",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421187899,
-    "wof:lastmodified":1566637760,
+    "wof:lastmodified":1582326391,
     "wof:name":"Rubavu",
     "wof:parent_id":85676791,
     "wof:placetype":"county",

--- a/data/421/190/841/421190841.geojson
+++ b/data/421/190/841/421190841.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009670,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f53ead4d697d5e9f415f17ffb85fc59a",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421190841,
-    "wof:lastmodified":1566637764,
+    "wof:lastmodified":1582326394,
     "wof:name":"Nyanza",
     "wof:parent_id":85676785,
     "wof:placetype":"county",

--- a/data/421/190/843/421190843.geojson
+++ b/data/421/190/843/421190843.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009670,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c24490e3761c858fbfcf248c3f46445b",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421190843,
-    "wof:lastmodified":1566637764,
+    "wof:lastmodified":1582326394,
     "wof:name":"Kamonyi",
     "wof:parent_id":85676785,
     "wof:placetype":"county",

--- a/data/421/190/845/421190845.geojson
+++ b/data/421/190/845/421190845.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009671,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e9f0005846a329f0052fd24bda40b5e",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421190845,
-    "wof:lastmodified":1566637763,
+    "wof:lastmodified":1582326393,
     "wof:name":"Rutsiro",
     "wof:parent_id":85676791,
     "wof:placetype":"county",

--- a/data/421/192/887/421192887.geojson
+++ b/data/421/192/887/421192887.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009752,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d9e231925d142e16e20d0a55571337a6",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421192887,
-    "wof:lastmodified":1566637750,
+    "wof:lastmodified":1582326386,
     "wof:name":"Muhanga",
     "wof:parent_id":85676785,
     "wof:placetype":"county",

--- a/data/421/192/889/421192889.geojson
+++ b/data/421/192/889/421192889.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009752,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"07ac39985810be823bbe42b7d96e7d57",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421192889,
-    "wof:lastmodified":1566637749,
+    "wof:lastmodified":1582326385,
     "wof:name":"Gakenke",
     "wof:parent_id":85676799,
     "wof:placetype":"county",

--- a/data/421/192/891/421192891.geojson
+++ b/data/421/192/891/421192891.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009752,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"25182a44ac602944215c165485abf4b3",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421192891,
-    "wof:lastmodified":1566637751,
+    "wof:lastmodified":1582326387,
     "wof:name":"Nyamasheke",
     "wof:parent_id":85676791,
     "wof:placetype":"county",

--- a/data/421/192/893/421192893.geojson
+++ b/data/421/192/893/421192893.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009752,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"24a1d85a08a658d30f838e37799224c7",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421192893,
-    "wof:lastmodified":1566637751,
+    "wof:lastmodified":1582326386,
     "wof:name":"Nyamagabe",
     "wof:parent_id":85676785,
     "wof:placetype":"county",

--- a/data/421/193/621/421193621.geojson
+++ b/data/421/193/621/421193621.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009777,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6a0019af81b02428db6398691224f24f",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421193621,
-    "wof:lastmodified":1566637753,
+    "wof:lastmodified":1582326388,
     "wof:name":"Nyagatare",
     "wof:parent_id":85676795,
     "wof:placetype":"county",

--- a/data/421/199/681/421199681.geojson
+++ b/data/421/199/681/421199681.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459009997,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4b6c52ef449242b86fabc742c335b34b",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421199681,
-    "wof:lastmodified":1566637765,
+    "wof:lastmodified":1582326395,
     "wof:name":"Bugesera",
     "wof:parent_id":85676795,
     "wof:placetype":"county",

--- a/data/421/202/327/421202327.geojson
+++ b/data/421/202/327/421202327.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459010114,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a58675f88f5df1d6d0c41d0a9058d8cb",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421202327,
-    "wof:lastmodified":1566637758,
+    "wof:lastmodified":1582326390,
     "wof:name":"Gasabo",
     "wof:parent_id":85676807,
     "wof:placetype":"county",

--- a/data/421/203/217/421203217.geojson
+++ b/data/421/203/217/421203217.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459010144,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"02b61328e769051e0a65f8d137cfe94a",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421203217,
-    "wof:lastmodified":1566637757,
+    "wof:lastmodified":1582326390,
     "wof:name":"Rulindo",
     "wof:parent_id":85676799,
     "wof:placetype":"county",

--- a/data/421/204/011/421204011.geojson
+++ b/data/421/204/011/421204011.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459010171,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f98d7f7fa9394dd1983bafaefa5abb22",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421204011,
-    "wof:lastmodified":1566637757,
+    "wof:lastmodified":1582326390,
     "wof:name":"Nyarugenge",
     "wof:parent_id":85676807,
     "wof:placetype":"county",

--- a/data/421/204/013/421204013.geojson
+++ b/data/421/204/013/421204013.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459010171,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"463536c01487fd9c6a18c668d7b1fd15",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421204013,
-    "wof:lastmodified":1566637755,
+    "wof:lastmodified":1582326389,
     "wof:name":"Gatsibo",
     "wof:parent_id":85676795,
     "wof:placetype":"county",

--- a/data/421/204/217/421204217.geojson
+++ b/data/421/204/217/421204217.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459010177,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fd1f9fa1e37accde48fa9200fcf98500",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421204217,
-    "wof:lastmodified":1566637756,
+    "wof:lastmodified":1582326389,
     "wof:name":"Kayonza",
     "wof:parent_id":85676795,
     "wof:placetype":"county",

--- a/data/421/204/219/421204219.geojson
+++ b/data/421/204/219/421204219.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"RW",
     "wof:created":1459010177,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"030787ea92163c52fe139bf84fd3785d",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421204219,
-    "wof:lastmodified":1566637756,
+    "wof:lastmodified":1582326389,
     "wof:name":"Huye",
     "wof:parent_id":85676785,
     "wof:placetype":"county",

--- a/data/856/323/03/85632303.geojson
+++ b/data/856/323/03/85632303.geojson
@@ -878,7 +878,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso"
+        "meso",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -934,6 +935,11 @@
     },
     "wof:country":"RW",
     "wof:country_alpha3":"RWA",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"7e0112deafa7015114b3beb7937ec5be",
     "wof:hierarchy":[
         {
@@ -952,7 +958,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566637086,
+    "wof:lastmodified":1582326370,
     "wof:name":"Rwanda",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/323/03/85632303.geojson
+++ b/data/856/323/03/85632303.geojson
@@ -878,8 +878,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -958,7 +957,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1582326370,
+    "wof:lastmodified":1583210129,
     "wof:name":"Rwanda",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/767/85/85676785.geojson
+++ b/data/856/767/85/85676785.geojson
@@ -304,6 +304,9 @@
         "wk:page":"Southern Province, Rwanda"
     },
     "wof:country":"RW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d1b191842c53aca9c7efbfed712262d",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566637093,
+    "wof:lastmodified":1582326375,
     "wof:name":"Southern",
     "wof:parent_id":85632303,
     "wof:placetype":"region",

--- a/data/856/767/91/85676791.geojson
+++ b/data/856/767/91/85676791.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Western Province, Rwanda"
     },
     "wof:country":"RW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0019f9571aa02e54a8e2d8f767e8bf8",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566637088,
+    "wof:lastmodified":1582326372,
     "wof:name":"Western",
     "wof:parent_id":85632303,
     "wof:placetype":"region",

--- a/data/856/767/95/85676795.geojson
+++ b/data/856/767/95/85676795.geojson
@@ -303,6 +303,9 @@
         "wk:page":"Eastern Province, Rwanda"
     },
     "wof:country":"RW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cfaf18a4715c2281f35e00ff75ea5eb3",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566637087,
+    "wof:lastmodified":1582326371,
     "wof:name":"Eastern",
     "wof:parent_id":85632303,
     "wof:placetype":"region",

--- a/data/856/767/99/85676799.geojson
+++ b/data/856/767/99/85676799.geojson
@@ -298,6 +298,9 @@
         "wk:page":"Northern Province, Rwanda"
     },
     "wof:country":"RW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"edb5eb759d47a7287621c757542ff9be",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566637092,
+    "wof:lastmodified":1582326374,
     "wof:name":"Northern",
     "wof:parent_id":85632303,
     "wof:placetype":"region",

--- a/data/856/768/07/85676807.geojson
+++ b/data/856/768/07/85676807.geojson
@@ -208,6 +208,9 @@
         "wd:id":"Q167196"
     },
     "wof:country":"RW",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"868fdc7a5c6da7da896741a240ba0b56",
     "wof:hierarchy":[
         {
@@ -227,7 +230,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1566637094,
+    "wof:lastmodified":1582326376,
     "wof:name":"Kigali City",
     "wof:parent_id":85632303,
     "wof:placetype":"region",

--- a/data/890/433/259/890433259.geojson
+++ b/data/890/433/259/890433259.geojson
@@ -211,6 +211,9 @@
     },
     "wof:country":"RW",
     "wof:created":1469051973,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"46ad468f3d4a22fccfa869bcc003fd3e",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":890433259,
-    "wof:lastmodified":1566637770,
+    "wof:lastmodified":1582326397,
     "wof:name":"Kibungo",
     "wof:parent_id":1108561297,
     "wof:placetype":"locality",

--- a/data/890/440/343/890440343.geojson
+++ b/data/890/440/343/890440343.geojson
@@ -214,6 +214,9 @@
     },
     "wof:country":"RW",
     "wof:created":1469052271,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dc4eaa02bb2abcb72538647baaf6519a",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":890440343,
-    "wof:lastmodified":1566637769,
+    "wof:lastmodified":1582326397,
     "wof:name":"Kibuye",
     "wof:parent_id":421182175,
     "wof:placetype":"locality",

--- a/data/890/453/975/890453975.geojson
+++ b/data/890/453/975/890453975.geojson
@@ -219,6 +219,9 @@
     },
     "wof:country":"RW",
     "wof:created":1469052880,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ef669472635e9e7309eab02e8bbc708",
     "wof:hierarchy":[
         {
@@ -230,7 +233,7 @@
         }
     ],
     "wof:id":890453975,
-    "wof:lastmodified":1566637770,
+    "wof:lastmodified":1582326397,
     "wof:name":"Cyangugu",
     "wof:parent_id":421176723,
     "wof:placetype":"locality",

--- a/data/890/453/977/890453977.geojson
+++ b/data/890/453/977/890453977.geojson
@@ -281,6 +281,9 @@
     },
     "wof:country":"RW",
     "wof:created":1469052881,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cd3067875603df37306597f10e685627",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         }
     ],
     "wof:id":890453977,
-    "wof:lastmodified":1566637770,
+    "wof:lastmodified":1582326397,
     "wof:name":"Gisenyi",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/454/125/890454125.geojson
+++ b/data/890/454/125/890454125.geojson
@@ -250,6 +250,7 @@
     "qs:photos_sr":0,
     "qs:pop_sr":"8",
     "src:geom_alt":[
+        "naturalearth",
         "quattroshapes_pg"
     ],
     "src:population":"geonames",
@@ -273,6 +274,10 @@
     },
     "wof:country":"RW",
     "wof:created":1469052887,
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e7e31418499afddc8500b158a4b4edb8",
     "wof:hierarchy":[
         {
@@ -284,7 +289,7 @@
         }
     ],
     "wof:id":890454125,
-    "wof:lastmodified":1561837348,
+    "wof:lastmodified":1582326397,
     "wof:name":"Butare",
     "wof:parent_id":421204219,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.