### PR TITLE
Name updates

### DIFF
--- a/data/856/323/03/85632303.geojson
+++ b/data/856/323/03/85632303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.056001,
-    "geom:area_square_m":25406779560.601997,
+    "geom:area_square_m":25406780703.490582,
     "geom:bbox":"28.861754,-2.83984,30.899118,-1.047572",
     "geom:latitude":-2.000401,
     "geom:longitude":29.925336,
@@ -52,6 +52,9 @@
     "name:arg_x_preferred":[
         "Ruanda"
     ],
+    "name:ary_x_preferred":[
+        "\u0631\u0648\u0627\u0646\u062f\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0631\u0648\u0627\u0646\u062f\u0627"
     ],
@@ -78,6 +81,9 @@
     ],
     "name:bam_x_variant":[
         "Ruwanda"
+    ],
+    "name:ban_x_preferred":[
+        "Rwanda"
     ],
     "name:bcl_x_preferred":[
         "Ruanda"
@@ -148,6 +154,12 @@
     "name:dan_x_preferred":[
         "Rwanda"
     ],
+    "name:deu_at_x_preferred":[
+        "Ruanda"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Ruanda"
+    ],
     "name:deu_x_preferred":[
         "Ruanda"
     ],
@@ -171,6 +183,12 @@
     ],
     "name:ell_x_preferred":[
         "\u03a1\u03bf\u03c5\u03ac\u03bd\u03c4\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Rwanda"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Rwanda"
     ],
     "name:eng_x_preferred":[
         "Rwanda"
@@ -242,6 +260,9 @@
     ],
     "name:gag_x_preferred":[
         "Ruanda"
+    ],
+    "name:gcr_x_preferred":[
+        "Rwanda"
     ],
     "name:gla_x_preferred":[
         "Rubhanda"
@@ -465,6 +486,9 @@
     "name:mon_x_preferred":[
         "\u0420\u0443\u0430\u043d\u0434\u0430"
     ],
+    "name:mri_x_preferred":[
+        "R\u0101wana"
+    ],
     "name:mrj_x_preferred":[
         "\u0420\u0443\u0430\u043d\u0434\u0430"
     ],
@@ -562,6 +586,9 @@
     "name:pol_x_preferred":[
         "Rwanda"
     ],
+    "name:por_br_x_preferred":[
+        "Ruanda"
+    ],
     "name:por_x_preferred":[
         "Ruanda"
     ],
@@ -629,6 +656,9 @@
     "name:sme_x_preferred":[
         "Rwanda"
     ],
+    "name:smo_x_preferred":[
+        "Rwanda"
+    ],
     "name:sna_x_preferred":[
         "Rwanda"
     ],
@@ -650,6 +680,12 @@
     "name:srd_x_preferred":[
         "Ruanda"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0420\u0443\u0430\u043d\u0434\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Ruanda"
+    ],
     "name:srp_x_preferred":[
         "\u0420\u0443\u0430\u043d\u0434\u0430"
     ],
@@ -669,6 +705,9 @@
         "Rwanda"
     ],
     "name:szl_x_preferred":[
+        "Rwanda"
+    ],
+    "name:szy_x_preferred":[
         "Rwanda"
     ],
     "name:tam_x_preferred":[
@@ -785,8 +824,32 @@
     "name:yue_x_preferred":[
         "\u76e7\u65fa\u9054"
     ],
+    "name:zea_x_preferred":[
+        "Rwanda"
+    ],
+    "name:zha_x_preferred":[
+        "Rwanda"
+    ],
+    "name:zho_cn_x_preferred":[
+        "\u5362\u65fa\u8fbe"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u76e7\u65fa\u9054"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Rwanda"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u5362\u65fa\u8fbe"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u5362\u65fa\u8fbe"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u5362\u65fa\u8fbe"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u76e7\u65fa\u9054"
     ],
     "name:zho_x_preferred":[
         "\u5362\u65fa\u8fbe"
@@ -958,7 +1021,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1583797427,
+    "wof:lastmodified":1587427672,
     "wof:name":"Rwanda",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.