### PR TITLE
Update megacity records

### DIFF
--- a/data/421/171/291/421171291.geojson
+++ b/data/421/171/291/421171291.geojson
@@ -20,7 +20,7 @@
     "mz:hierarchy_label":1,
     "mz:is_approximate":1,
     "mz:is_current":1,
-    "mz:min_zoom":5.0,
+    "mz:min_zoom":5.1,
     "mz:note":"quattroshapes points import (201603)",
     "name:afr_x_preferred":[
         "Kigali"
@@ -461,6 +461,7 @@
     "wof:concordances":{
         "gn:id":202061,
         "gp:id":1511263,
+        "ne:id":1159149385,
         "qs_pg:id":1226597,
         "wd:id":"Q3859",
         "wk:page":"Kigali"
@@ -484,7 +485,8 @@
         }
     ],
     "wof:id":421171291,
-    "wof:lastmodified":1607390886,
+    "wof:lastmodified":1608688170,
+    "wof:megacity":1,
     "wof:name":"Kigali",
     "wof:parent_id":421204011,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary