### PR TITLE
rw concordances, placetype local, and more

### DIFF
--- a/data/110/856/129/5/1108561295.geojson
+++ b/data/110/856/129/5/1108561295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054987,
-    "geom:area_square_m":679557615.975338,
+    "geom:area_square_m":679557615.97537,
     "geom:bbox":"29.3981745668,-2.08585593653,29.6751739202,-1.72205452365",
     "geom:latitude":-1.877845,
     "geom:longitude":29.569465,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"RW.OU.NR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1473983353,
-    "wof:geomhash":"efc77f59ade84583f2361beadf5ad143",
+    "wof:geomhash":"fa80a47ebec7332a4a7bad1e2f88ec06",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108561295,
-    "wof:lastmodified":1566637563,
+    "wof:lastmodified":1695886294,
     "wof:name":"Ngororero",
     "wof:parent_id":85676791,
     "wof:placetype":"county",

--- a/data/110/856/129/7/1108561297.geojson
+++ b/data/110/856/129/7/1108561297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070613,
-    "geom:area_square_m":872512651.186021,
+    "geom:area_square_m":872512651.186174,
     "geom:bbox":"30.2595894113,-2.35009945784,30.6609803038,-2.04552405409",
     "geom:latitude":-2.182993,
     "geom:longitude":30.457188,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"RW.ES.NM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1473983355,
-    "wof:geomhash":"3b742d135ab404ae156056c859956776",
+    "wof:geomhash":"1f57ca69998802e133efe36c4df5dcad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108561297,
-    "wof:lastmodified":1566637563,
+    "wof:lastmodified":1695886295,
     "wof:name":"Ngoma",
     "wof:parent_id":85676795,
     "wof:placetype":"county",

--- a/data/110/856/129/9/1108561299.geojson
+++ b/data/110/856/129/9/1108561299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050887,
-    "geom:area_square_m":628769005.774396,
+    "geom:area_square_m":628769005.774445,
     "geom:bbox":"29.56130456,-2.28645675412,29.9906773749,-2.10052559803",
     "geom:latitude":-2.193598,
     "geom:longitude":29.771761,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"RW.SU.RH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1473983378,
-    "wof:geomhash":"125d5fd9c9918b30c588d4e0b6c00369",
+    "wof:geomhash":"62b70e9340ccf2f90398080b9d8e14b9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108561299,
-    "wof:lastmodified":1566637562,
+    "wof:lastmodified":1695886293,
     "wof:name":"Ruhango",
     "wof:parent_id":85676785,
     "wof:placetype":"county",

--- a/data/110/856/130/1/1108561301.geojson
+++ b/data/110/856/130/1/1108561301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055309,
-    "geom:area_square_m":683194552.609216,
+    "geom:area_square_m":683194669.253561,
     "geom:bbox":"29.697939,-2.820076,29.970904,-2.396862",
     "geom:latitude":-2.618112,
     "geom:longitude":29.843603,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"RW.SU.GG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1473983382,
-    "wof:geomhash":"8bb39396a1af8a95cbdfe0af94c60925",
+    "wof:geomhash":"14e3f2c07bbedaae85d28bf3d44ad06b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108561301,
-    "wof:lastmodified":1642551742,
+    "wof:lastmodified":1695886505,
     "wof:name":"Gisagara",
     "wof:parent_id":85676785,
     "wof:placetype":"county",

--- a/data/110/856/130/3/1108561303.geojson
+++ b/data/110/856/130/3/1108561303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082237,
-    "geom:area_square_m":1015754949.088753,
+    "geom:area_square_m":1015754861.234706,
     "geom:bbox":"29.327891,-2.84023,29.746892,-2.532449",
     "geom:latitude":-2.694844,
     "geom:longitude":29.516876,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"RW.SU.NU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1473983385,
-    "wof:geomhash":"337602c48483e42dd19a559d0becd67d",
+    "wof:geomhash":"bff5b015926163a22ff1fce51b6ea09f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108561303,
-    "wof:lastmodified":1627522740,
+    "wof:lastmodified":1695886444,
     "wof:name":"Nyaruguru",
     "wof:parent_id":85676785,
     "wof:placetype":"county",

--- a/data/421/169/419/421169419.geojson
+++ b/data/421/169/419/421169419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043706,
-    "geom:area_square_m":540212607.35354,
+    "geom:area_square_m":540212733.045828,
     "geom:bbox":"29.380761,-1.776997,29.640003,-1.506018",
     "geom:latitude":-1.647392,
     "geom:longitude":29.510515,
@@ -140,12 +140,13 @@
         "wd:id":"Q2424699",
         "wk:page":"Nyabihu District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459008809,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fbd5c2b912031a51e2039df77153578d",
+    "wof:geomhash":"55792410db31afa37b59a86478a74862",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421169419,
-    "wof:lastmodified":1690860244,
+    "wof:lastmodified":1695886703,
     "wof:name":"Nyabihu",
     "wof:parent_id":85676791,
     "wof:placetype":"county",

--- a/data/421/175/213/421175213.geojson
+++ b/data/421/175/213/421175213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067341,
-    "geom:area_square_m":832348952.363895,
+    "geom:area_square_m":832348821.307718,
     "geom:bbox":"29.943952,-1.846311,30.275624,-1.3917",
     "geom:latitude":-1.621577,
     "geom:longitude":30.113871,
@@ -134,12 +134,13 @@
         "wd:id":"Q2424750",
         "wk:page":"Gicumbi District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009059,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b0b8ecb8f4712ea0b8a0361a5bed9f3e",
+    "wof:geomhash":"68bca6a64cb7f0d52dfedae15b14a471",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421175213,
-    "wof:lastmodified":1690860249,
+    "wof:lastmodified":1695886707,
     "wof:name":"Gicumbi",
     "wof:parent_id":85676799,
     "wof:placetype":"county",

--- a/data/421/175/701/421175701.geojson
+++ b/data/421/175/701/421175701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096643,
-    "geom:area_square_m":1194099193.686715,
+    "geom:area_square_m":1194099485.799,
     "geom:bbox":"30.457762,-2.420319,30.899747,-1.971525",
     "geom:latitude":-2.234396,
     "geom:longitude":30.710345,
@@ -131,12 +131,13 @@
         "wd:id":"Q596210",
         "wk:page":"Kirehe District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009076,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"42c81ced64b38c3ecd4625f86733e821",
+    "wof:geomhash":"442665128c48d8cfdd9ba6ca25f5f1f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421175701,
-    "wof:lastmodified":1690860249,
+    "wof:lastmodified":1695886708,
     "wof:name":"Kirehe",
     "wof:parent_id":85676795,
     "wof:placetype":"county",

--- a/data/421/176/723/421176723.geojson
+++ b/data/421/176/723/421176723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074761,
-    "geom:area_square_m":923507906.428605,
+    "geom:area_square_m":923507716.217188,
     "geom:bbox":"28.861731,-2.744671,29.367931,-2.373714",
     "geom:latitude":-2.565372,
     "geom:longitude":29.087431,
@@ -164,12 +164,13 @@
         "wd:id":"Q781590",
         "wk:page":"Rusizi District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009117,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8b7a24f44b5b19f66159425948aa5138",
+    "wof:geomhash":"fae98deb246f54b9c7f4803ab5588228",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":421176723,
-    "wof:lastmodified":1690860252,
+    "wof:lastmodified":1695886727,
     "wof:name":"Rusizi",
     "wof:parent_id":85676791,
     "wof:placetype":"county",

--- a/data/421/180/243/421180243.geojson
+++ b/data/421/180/243/421180243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052437,
-    "geom:area_square_m":648177958.103363,
+    "geom:area_square_m":648178087.16336,
     "geom:bbox":"29.656229,-1.612936,29.997563,-1.308887",
     "geom:latitude":-1.466243,
     "geom:longitude":29.826545,
@@ -131,12 +131,13 @@
         "wd:id":"Q2724063",
         "wk:page":"Burera District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009249,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7f5028a891757fa2148a936ffc8b1546",
+    "wof:geomhash":"16b047a7e19e5c76f5fef4b341798117",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421180243,
-    "wof:lastmodified":1690860247,
+    "wof:lastmodified":1695886706,
     "wof:name":"Burera",
     "wof:parent_id":85676799,
     "wof:placetype":"county",

--- a/data/421/182/175/421182175.geojson
+++ b/data/421/182/175/421182175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064122,
-    "geom:area_square_m":792316799.369581,
+    "geom:area_square_m":792316904.396295,
     "geom:bbox":"29.248994,-2.324429,29.624545,-2.023818",
     "geom:latitude":-2.156707,
     "geom:longitude":29.431321,
@@ -146,12 +146,13 @@
         "wd:id":"Q429825",
         "wk:page":"Karongi District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009321,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8cacf7bbe024f8b5784cece28b0f5119",
+    "wof:geomhash":"45a6b0780fdaf2f1318fbbcba1906b68",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":421182175,
-    "wof:lastmodified":1690860251,
+    "wof:lastmodified":1695886710,
     "wof:name":"Karongi",
     "wof:parent_id":85676791,
     "wof:placetype":"county",

--- a/data/421/182/309/421182309.geojson
+++ b/data/421/182/309/421182309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013577,
-    "geom:area_square_m":167777814.990198,
+    "geom:area_square_m":167777884.197184,
     "geom:bbox":"30.048465,-2.079803,30.236822,-1.952743",
     "geom:latitude":-2.008864,
     "geom:longitude":30.143725,
@@ -128,12 +128,13 @@
         "wd:id":"Q2424726",
         "wk:page":"Kicukiro District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009325,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"49f4f18c37f63b903a02d9dd5acccb8c",
+    "wof:geomhash":"0663c210ab67ac758104c5f04efe0985",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":421182309,
-    "wof:lastmodified":1690860251,
+    "wof:lastmodified":1695886711,
     "wof:name":"Kicukiro",
     "wof:parent_id":85676807,
     "wof:placetype":"county",

--- a/data/421/187/891/421187891.geojson
+++ b/data/421/187/891/421187891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055336,
-    "geom:area_square_m":683833555.207626,
+    "geom:area_square_m":683833502.448881,
     "geom:bbox":"30.220593,-2.13352,30.488901,-1.823647",
     "geom:latitude":-1.975497,
     "geom:longitude":30.354736,
@@ -135,12 +135,13 @@
         "wd:id":"Q921255",
         "wk:page":"Rwamagana District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009527,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"24a5ee28dec83b5517b8c28cf553d46f",
+    "wof:geomhash":"3f525dd30265e80f882f9af465e9d9d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421187891,
-    "wof:lastmodified":1690860248,
+    "wof:lastmodified":1695886707,
     "wof:name":"Rwamagana",
     "wof:parent_id":85676795,
     "wof:placetype":"county",

--- a/data/421/187/897/421187897.geojson
+++ b/data/421/187/897/421187897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042862,
-    "geom:area_square_m":529818704.119798,
+    "geom:area_square_m":529818586.336279,
     "geom:bbox":"29.450002,-1.598849,29.765273,-1.385807",
     "geom:latitude":-1.498535,
     "geom:longitude":29.606597,
@@ -134,12 +134,13 @@
         "wd:id":"Q2360921",
         "wk:page":"Musanze District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009527,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fef7d3c5768ca8fcfe8f0d7843513b55",
+    "wof:geomhash":"af4652f36b202f40194e6a1f5041d797",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421187897,
-    "wof:lastmodified":1690860248,
+    "wof:lastmodified":1695886709,
     "wof:name":"Musanze",
     "wof:parent_id":85676799,
     "wof:placetype":"county",

--- a/data/421/187/899/421187899.geojson
+++ b/data/421/187/899/421187899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027518,
-    "geom:area_square_m":340125888.712597,
+    "geom:area_square_m":340126039.472078,
     "geom:bbox":"29.242867,-1.772667,29.437181,-1.507892",
     "geom:latitude":-1.653969,
     "geom:longitude":29.342693,
@@ -143,12 +143,13 @@
         "wd:id":"Q2424738",
         "wk:page":"Rubavu District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009527,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d9754e3027292ef5d31cc11dd13c36b0",
+    "wof:geomhash":"233b28df0a827a9f5fd3d0735d470038",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":421187899,
-    "wof:lastmodified":1690860248,
+    "wof:lastmodified":1695886707,
     "wof:name":"Rubavu",
     "wof:parent_id":85676791,
     "wof:placetype":"county",

--- a/data/421/190/841/421190841.geojson
+++ b/data/421/190/841/421190841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054629,
-    "geom:area_square_m":674941644.52443,
+    "geom:area_square_m":674941740.008857,
     "geom:bbox":"29.581655,-2.455769,29.984798,-2.231623",
     "geom:latitude":-2.335861,
     "geom:longitude":29.793463,
@@ -134,12 +134,13 @@
         "hasc:id":"RW.SU.NZ",
         "qs_pg:id":56218
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009670,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7d26d85150ad09ecacedcb4225ce12cf",
+    "wof:geomhash":"4fe8fe547c6bcab0d47dff51b868b9f6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421190841,
-    "wof:lastmodified":1636496689,
+    "wof:lastmodified":1695886728,
     "wof:name":"Nyanza",
     "wof:parent_id":85676785,
     "wof:placetype":"county",

--- a/data/421/190/843/421190843.geojson
+++ b/data/421/190/843/421190843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053637,
-    "geom:area_square_m":662824780.943638,
+    "geom:area_square_m":662825045.688584,
     "geom:bbox":"29.784052,-2.202538,30.02081,-1.852911",
     "geom:latitude":-2.009446,
     "geom:longitude":29.902403,
@@ -134,12 +134,13 @@
         "wd:id":"Q2424592",
         "wk:page":"Kamonyi District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009670,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"14b332a8f5f8c89e1e3933236f1a18ad",
+    "wof:geomhash":"a9f9efe051c6a77303892ec0155a7c60",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421190843,
-    "wof:lastmodified":1690860250,
+    "wof:lastmodified":1695886710,
     "wof:name":"Kamonyi",
     "wof:parent_id":85676785,
     "wof:placetype":"county",

--- a/data/421/190/845/421190845.geojson
+++ b/data/421/190/845/421190845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053796,
-    "geom:area_square_m":664832550.46698,
+    "geom:area_square_m":664832573.486627,
     "geom:bbox":"29.143275,-2.070191,29.565621,-1.729317",
     "geom:latitude":-1.903725,
     "geom:longitude":29.399042,
@@ -137,12 +137,13 @@
         "wd:id":"Q2724023",
         "wk:page":"Rutsiro District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009671,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"48ccdf4da89c001fc642325acd197a4f",
+    "wof:geomhash":"b7723167cd50eefc8333360b2e9875b9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421190845,
-    "wof:lastmodified":1690860249,
+    "wof:lastmodified":1695886709,
     "wof:name":"Rutsiro",
     "wof:parent_id":85676791,
     "wof:placetype":"county",

--- a/data/421/192/887/421192887.geojson
+++ b/data/421/192/887/421192887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052561,
-    "geom:area_square_m":649549782.120979,
+    "geom:area_square_m":649549807.523745,
     "geom:bbox":"29.612422,-2.146022,29.817453,-1.731178",
     "geom:latitude":-1.954891,
     "geom:longitude":29.722725,
@@ -131,12 +131,13 @@
         "wd:id":"Q2632789",
         "wk:page":"Muhanga District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009752,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"999ffe0bad9315fa168b6d2b6c9f6986",
+    "wof:geomhash":"0219e07789ae61caacd4fe50ebdcc555",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421192887,
-    "wof:lastmodified":1690860242,
+    "wof:lastmodified":1695886701,
     "wof:name":"Muhanga",
     "wof:parent_id":85676785,
     "wof:placetype":"county",

--- a/data/421/192/889/421192889.geojson
+++ b/data/421/192/889/421192889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057213,
-    "geom:area_square_m":707135838.539974,
+    "geom:area_square_m":707135692.034398,
     "geom:bbox":"29.632457,-1.873297,29.932653,-1.549664",
     "geom:latitude":-1.698531,
     "geom:longitude":29.784237,
@@ -134,12 +134,13 @@
         "wd:id":"Q781985",
         "wk:page":"Gakenke District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009752,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"14657a33fa0b90bd2ed2d35a034df010",
+    "wof:geomhash":"5faa2f5d8ed3275bab51263d45bd24d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421192889,
-    "wof:lastmodified":1690860242,
+    "wof:lastmodified":1695886700,
     "wof:name":"Gakenke",
     "wof:parent_id":85676799,
     "wof:placetype":"county",

--- a/data/421/192/891/421192891.geojson
+++ b/data/421/192/891/421192891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077148,
-    "geom:area_square_m":953126639.043588,
+    "geom:area_square_m":953126429.239519,
     "geom:bbox":"28.964883,-2.569074,29.343969,-2.150156",
     "geom:latitude":-2.373509,
     "geom:longitude":29.16623,
@@ -131,12 +131,13 @@
         "wd:id":"Q2005905",
         "wk:page":"Nyamasheke District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009752,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e8f6a0eefcb5356bc5adf40c57c89bce",
+    "wof:geomhash":"57027f73290e939576705a6c5582a5b2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421192891,
-    "wof:lastmodified":1690860243,
+    "wof:lastmodified":1695886701,
     "wof:name":"Nyamasheke",
     "wof:parent_id":85676791,
     "wof:placetype":"county",

--- a/data/421/192/893/421192893.geojson
+++ b/data/421/192/893/421192893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088713,
-    "geom:area_square_m":1095977181.198656,
+    "geom:area_square_m":1095977105.936804,
     "geom:bbox":"29.264653,-2.600329,29.666093,-2.199791",
     "geom:latitude":-2.411356,
     "geom:longitude":29.469879,
@@ -131,12 +131,13 @@
         "wd:id":"Q2632783",
         "wk:page":"Nyamagabe District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009752,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d5f4cb23a94e5e330c2ace460f9b4c3e",
+    "wof:geomhash":"1ef8c24ac7bc218c0e0751d29bbd5c52",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421192893,
-    "wof:lastmodified":1690860242,
+    "wof:lastmodified":1695886701,
     "wof:name":"Nyamagabe",
     "wof:parent_id":85676785,
     "wof:placetype":"county",

--- a/data/421/193/621/421193621.geojson
+++ b/data/421/193/621/421193621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.155871,
-    "geom:area_square_m":1926842214.902205,
+    "geom:area_square_m":1926842359.301935,
     "geom:bbox":"30.069891,-1.547976,30.741098,-1.047167",
     "geom:latitude":-1.338249,
     "geom:longitude":30.379925,
@@ -140,12 +140,13 @@
         "qs_pg:id":12178,
         "wd:id":"Q3562393"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009777,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"18a5c68740423c12e3aa52ec277a83d8",
+    "wof:geomhash":"48c141cda74fe875e39550509007932d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421193621,
-    "wof:lastmodified":1690860244,
+    "wof:lastmodified":1695886703,
     "wof:name":"Nyagatare",
     "wof:parent_id":85676795,
     "wof:placetype":"county",

--- a/data/421/199/681/421199681.geojson
+++ b/data/421/199/681/421199681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105157,
-    "geom:area_square_m":1299289376.539844,
+    "geom:area_square_m":1299289104.744192,
     "geom:bbox":"29.959209,-2.438184,30.374481,-2.028219",
     "geom:latitude":-2.239766,
     "geom:longitude":30.150166,
@@ -131,12 +131,13 @@
         "wd:id":"Q2724056",
         "wk:page":"Bugesera District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459009997,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9b379c0e1a0abf6fae9bc353430e76c1",
+    "wof:geomhash":"b63d21ec7091f3ecda863214b51052b4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421199681,
-    "wof:lastmodified":1690860250,
+    "wof:lastmodified":1695886711,
     "wof:name":"Bugesera",
     "wof:parent_id":85676795,
     "wof:placetype":"county",

--- a/data/421/202/327/421202327.geojson
+++ b/data/421/202/327/421202327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034892,
-    "geom:area_square_m":431210987.032227,
+    "geom:area_square_m":431210983.58532,
     "geom:bbox":"29.989085,-1.987697,30.27715,-1.779561",
     "geom:latitude":-1.891447,
     "geom:longitude":30.142212,
@@ -131,12 +131,13 @@
         "wd:id":"Q2424659",
         "wk:page":"Gasabo District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459010114,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"293acdb6c13036a964750914768108b0",
+    "wof:geomhash":"446145b30d9a1d8eff5f8e9d029351de",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421202327,
-    "wof:lastmodified":1690860247,
+    "wof:lastmodified":1695886705,
     "wof:name":"Gasabo",
     "wof:parent_id":85676807,
     "wof:placetype":"county",

--- a/data/421/203/217/421203217.geojson
+++ b/data/421/203/217/421203217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04611,
-    "geom:area_square_m":569896203.540516,
+    "geom:area_square_m":569896182.661273,
     "geom:bbox":"29.864267,-1.913378,30.133111,-1.589634",
     "geom:latitude":-1.739284,
     "geom:longitude":29.987227,
@@ -131,12 +131,13 @@
         "wd:id":"Q2424625",
         "wk:page":"Rulindo District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459010144,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c66a3a96b88066735f15e26cbf4dab21",
+    "wof:geomhash":"8c400d15d1b2a17141c1016722222d78",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421203217,
-    "wof:lastmodified":1690860246,
+    "wof:lastmodified":1695886705,
     "wof:name":"Rulindo",
     "wof:parent_id":85676799,
     "wof:placetype":"county",

--- a/data/421/204/011/421204011.geojson
+++ b/data/421/204/011/421204011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010768,
-    "geom:area_square_m":133064663.748635,
+    "geom:area_square_m":133064625.172082,
     "geom:bbox":"29.977519,-2.075769,30.086842,-1.866774",
     "geom:latitude":-1.992005,
     "geom:longitude":30.028865,
@@ -128,12 +128,13 @@
         "wd:id":"Q2424641",
         "wk:page":"Nyarugenge District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459010171,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9a5eec47360492785534c99f5447f1b6",
+    "wof:geomhash":"6b78a3fc90bd9d009d61f08d81a2f9ef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":421204011,
-    "wof:lastmodified":1690860246,
+    "wof:lastmodified":1695886706,
     "wof:name":"Nyarugenge",
     "wof:parent_id":85676807,
     "wof:placetype":"county",

--- a/data/421/204/013/421204013.geojson
+++ b/data/421/204/013/421204013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.128754,
-    "geom:area_square_m":1591433487.566339,
+    "geom:area_square_m":1591433754.525816,
     "geom:bbox":"30.162488,-1.87599,30.839152,-1.458217",
     "geom:latitude":-1.619076,
     "geom:longitude":30.445392,
@@ -128,12 +128,13 @@
         "wd:id":"Q2724046",
         "wk:page":"Gatsibo District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459010171,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3b447f2538739813d76967b582beb91c",
+    "wof:geomhash":"78bf7b7e371161d76d324d299c38d9f6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":421204013,
-    "wof:lastmodified":1690860245,
+    "wof:lastmodified":1695886703,
     "wof:name":"Gatsibo",
     "wof:parent_id":85676795,
     "wof:placetype":"county",

--- a/data/421/204/217/421204217.geojson
+++ b/data/421/204/217/421204217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.157031,
-    "geom:area_square_m":1940704915.52686,
+    "geom:area_square_m":1940703876.730184,
     "geom:bbox":"30.419767,-2.124998,30.839394,-1.599708",
     "geom:latitude":-1.845126,
     "geom:longitude":30.641979,
@@ -125,12 +125,13 @@
         "wd:id":"Q426211",
         "wk:page":"Kayonza District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459010177,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2c8d64cae7f1704efa6d880f71ba3488",
+    "wof:geomhash":"7555539efef2182655742a2f522c3fab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421204217,
-    "wof:lastmodified":1690860245,
+    "wof:lastmodified":1695886704,
     "wof:name":"Kayonza",
     "wof:parent_id":85676795,
     "wof:placetype":"county",

--- a/data/421/204/219/421204219.geojson
+++ b/data/421/204/219/421204219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047251,
-    "geom:area_square_m":583702393.164189,
+    "geom:area_square_m":583702375.521442,
     "geom:bbox":"29.583391,-2.695662,29.846033,-2.368619",
     "geom:latitude":-2.524645,
     "geom:longitude":29.708795,
@@ -140,12 +140,13 @@
         "wd:id":"Q2632827",
         "wk:page":"Huye District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"RW",
     "wof:created":1459010177,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"936de192d950d1cd221cda6055bd4b01",
+    "wof:geomhash":"ac235f4a2ba6efce1fd5eb625f882213",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421204219,
-    "wof:lastmodified":1690860245,
+    "wof:lastmodified":1695886704,
     "wof:name":"Huye",
     "wof:parent_id":85676785,
     "wof:placetype":"county",

--- a/data/856/323/03/85632303.geojson
+++ b/data/856/323/03/85632303.geojson
@@ -1126,6 +1126,7 @@
         "hasc:id":"RW",
         "icao:code":"9XR",
         "ioc:id":"RWA",
+        "iso:code":"RW",
         "itu:id":"RRW",
         "loc:id":"n81025976",
         "m49:code":"646",
@@ -1140,6 +1141,7 @@
         "wk:page":"Rwanda",
         "wmo:id":"RW"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"RW",
     "wof:country_alpha3":"RWA",
     "wof:geom_alt":[
@@ -1165,7 +1167,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1694639518,
+    "wof:lastmodified":1695881174,
     "wof:name":"Rwanda",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/767/85/85676785.geojson
+++ b/data/856/767/85/85676785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.485225,
-    "geom:area_square_m":5994714289.424584,
+    "geom:area_square_m":5994714569.107028,
     "geom:bbox":"29.264653,-2.84023,30.02081,-1.731178",
     "geom:latitude":-2.368792,
     "geom:longitude":29.687,
@@ -324,17 +324,19 @@
         "gn:id":6413341,
         "gp:id":55864752,
         "hasc:id":"RW.SU",
+        "iso:code":"RW-05",
         "iso:id":"RW-05",
         "qs_pg:id":1104171,
         "unlc:id":"RW-05",
         "wd:id":"Q853162",
         "wk:page":"Southern Province, Rwanda"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"RW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"120cde80371c391c88add9ce70649338",
+    "wof:geomhash":"4ceb5490414aee09a2e79e6035e28066",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -353,7 +355,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860238,
+    "wof:lastmodified":1695884845,
     "wof:name":"Southern",
     "wof:parent_id":85632303,
     "wof:placetype":"region",

--- a/data/856/767/91/85676791.geojson
+++ b/data/856/767/91/85676791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.396038,
-    "geom:area_square_m":4893680007.351414,
+    "geom:area_square_m":4893679917.1371,
     "geom:bbox":"28.861731,-2.744671,29.675174,-1.506018",
     "geom:latitude":-2.111863,
     "geom:longitude":29.332142,
@@ -322,16 +322,18 @@
         "gn:id":6413340,
         "gp:id":55864753,
         "hasc:id":"RW.OU",
+        "iso:code":"RW-04",
         "iso:id":"RW-04",
         "qs_pg:id":224254,
         "wd:id":"Q737354",
         "wk:page":"Western Province, Rwanda"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"RW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"14c45e65fc95348818941afa53804957",
+    "wof:geomhash":"125691213ce63354be0108bfdbecd4b9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -350,7 +352,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860236,
+    "wof:lastmodified":1695884844,
     "wof:name":"Western",
     "wof:parent_id":85632303,
     "wof:placetype":"region",

--- a/data/856/767/95/85676795.geojson
+++ b/data/856/767/95/85676795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.769405,
-    "geom:area_square_m":9508715394.615686,
+    "geom:area_square_m":9508714569.909859,
     "geom:bbox":"29.959209,-2.438184,30.899747,-1.047167",
     "geom:latitude":-1.847828,
     "geom:longitude":30.459745,
@@ -322,16 +322,18 @@
         "gn:id":6413337,
         "gp:id":55864749,
         "hasc:id":"RW.ES",
+        "iso:code":"RW-02",
         "iso:id":"RW-02",
         "qs_pg:id":224253,
         "wd:id":"Q853152",
         "wk:page":"Eastern Province, Rwanda"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"RW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b74f4ec74d97cd38bedeb6dfe5d66450",
+    "wof:geomhash":"ddffe2d3cda122aaab774085167a28de",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -350,7 +352,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860235,
+    "wof:lastmodified":1695884843,
     "wof:name":"Eastern",
     "wof:parent_id":85632303,
     "wof:placetype":"region",

--- a/data/856/767/99/85676799.geojson
+++ b/data/856/767/99/85676799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.265963,
-    "geom:area_square_m":3287377656.667682,
+    "geom:area_square_m":3287377369.503274,
     "geom:bbox":"29.450002,-1.913378,30.275624,-1.308887",
     "geom:latitude":-1.608083,
     "geom:longitude":29.882605,
@@ -312,17 +312,19 @@
         "gn:id":6413339,
         "gp:id":55864751,
         "hasc:id":"RW.NO",
+        "iso:code":"RW-03",
         "iso:id":"RW-03",
         "qs_pg:id":898989,
         "unlc:id":"RW-03",
         "wd:id":"Q845807",
         "wk:page":"Northern Province, Rwanda"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"RW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01e824afe8134dae5578efd7d82431b6",
+    "wof:geomhash":"424bfec2e767e3fc19e63e05ad2ef09f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -341,7 +343,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860237,
+    "wof:lastmodified":1695884846,
     "wof:name":"Northern",
     "wof:parent_id":85632303,
     "wof:placetype":"region",

--- a/data/856/768/07/85676807.geojson
+++ b/data/856/768/07/85676807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059237,
-    "geom:area_square_m":732053465.77128,
+    "geom:area_square_m":732053492.954649,
     "geom:bbox":"29.977519,-2.079803,30.27715,-1.779561",
     "geom:latitude":-1.936638,
     "geom:longitude":30.121955,
@@ -207,15 +207,17 @@
         "gn:id":6413338,
         "gp:id":55864750,
         "hasc:id":"RW.KV",
+        "iso:code":"RW-01",
         "iso:id":"RW-01",
         "qs_pg:id":900825,
         "wd:id":"Q167196"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"RW",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c2b4cd2a74e9820c1390c75e737bc851",
+    "wof:geomhash":"7ac91b3c9121e0452b658da558fcb92c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -234,7 +236,7 @@
         "fra",
         "eng"
     ],
-    "wof:lastmodified":1690860238,
+    "wof:lastmodified":1695884356,
     "wof:name":"Kigali City",
     "wof:parent_id":85632303,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.